### PR TITLE
Fix PSR-0 violations

### DIFF
--- a/src/Mailchimp.php
+++ b/src/Mailchimp.php
@@ -120,7 +120,7 @@ class Mailchimp
         $this->conversations                                = new Mailchimp_Conversations($this);
         $this->conversations->messages                      = new Mailchimp_ConversationsMessages($this);
         $this->ecommerce                                    = new Mailchimp_Ecommerce($this);
-        $this->ecommerce->stores                            = new Mailchimp_EcommerceStore($this);
+        $this->ecommerce->stores                            = new Mailchimp_EcommerceStores($this);
         $this->ecommerce->carts                             = new Mailchimp_EcommerceCarts($this);
         $this->ecommerce->customers                         = new Mailchimp_EcommerceCustomers($this);
         $this->ecommerce->orders                            = new Mailchimp_EcommerceOrders($this);

--- a/src/Mailchimp.php
+++ b/src/Mailchimp.php
@@ -137,7 +137,7 @@ class Mailchimp
         $this->lists->clients                               = new Mailchimp_ListsClients($this);
         $this->lists->growthHistory                         = new Mailchimp_ListsGrowthHistory($this);
         $this->lists->interestCategory                      = new Mailchimp_ListsInterestCategory($this);
-        $this->lists->interestCategory->interests           = new Mailchimp_ListInterestCategoryInterests($this);
+        $this->lists->interestCategory->interests           = new Mailchimp_ListsInterestCategoryInterests($this);
         $this->lists->members                               = new Mailchimp_ListsMembers($this);
         $this->lists->members->memberActivity               = new Mailchimp_ListsMembersActivity($this);
         $this->lists->members->memberGoal                   = new Mailchimp_ListsMembersGoals($this);

--- a/src/Mailchimp.php
+++ b/src/Mailchimp.php
@@ -109,7 +109,7 @@ class Mailchimp
         $this->authorizedApps                               = new Mailchimp_AuthorizedApps($this);
         $this->automation                                   = new Mailchimp_Automation($this);
         $this->automation->emails                           = new Mailchimp_AutomationEmails($this);
-        $this->automation->emails->queue                    = new Mailchimp_AutomationEmailsQuque($this);
+        $this->automation->emails->queue                    = new Mailchimp_AutomationEmailsQueue($this);
         $this->automation->removedSubscribers               = new Mailchimp_AutomationRemovedSubscribers($this);
         $this->batchOperation                               = new Mailchimp_BatchOperations($this);
         $this->campaignFolders                              = new Mailchimp_CampaignFolders($this);

--- a/src/Mailchimp/AutomationEmails.php
+++ b/src/Mailchimp/AutomationEmails.php
@@ -13,7 +13,7 @@
 class Mailchimp_AutomationEmails extends Mailchimp_Abstract
 {
     /**
-     * @var Mailchimp_AutomationEmailsQuque
+     * @var Mailchimp_AutomationEmailsQueue
      */
     public $queue;
 

--- a/src/Mailchimp/AutomationEmailsQueue.php
+++ b/src/Mailchimp/AutomationEmailsQueue.php
@@ -10,7 +10,7 @@
  * @date: 5/2/16 4:13 PM
  * @file: AutomationEmailsQueue.php
  */
-class Mailchimp_AutomationEmailsQuque extends Mailchimp_Abstract
+class Mailchimp_AutomationEmailsQueue extends Mailchimp_Abstract
 {
     /**
      * @param $workflowId           The unique id for the Automation workflow.

--- a/src/Mailchimp/AutomationEmailsQuque.php
+++ b/src/Mailchimp/AutomationEmailsQuque.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * @deprecated 3.0.32 Please use correct spelling of 'queue'.
+ */
+class Mailchimp_AutomationEmailsQuque extends Mailchimp_AutomationEmailsQueue
+{
+}

--- a/src/Mailchimp/Ecommerce.php
+++ b/src/Mailchimp/Ecommerce.php
@@ -13,7 +13,7 @@
 class Mailchimp_Ecommerce extends Mailchimp_Abstract
 {
     /**
-     * @var Mailchimp_EcommerceStore
+     * @var Mailchimp_EcommerceStores
      */
     public $stores;
     /**

--- a/src/Mailchimp/EcommerceStore.php
+++ b/src/Mailchimp/EcommerceStore.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * @deprecated 3.0.32 Please use correct spelling of 'stores'.
+ */
+class Mailchimp_EcommerceStore extends Mailchimp_EcommerceStores
+{
+}

--- a/src/Mailchimp/EcommerceStores.php
+++ b/src/Mailchimp/EcommerceStores.php
@@ -10,7 +10,7 @@
  * @date: 4/29/16 4:08 PM
  * @file: EcommerceStores.php
  */
-class Mailchimp_EcommerceStore  extends Mailchimp_Abstract
+class Mailchimp_EcommerceStores extends Mailchimp_Abstract
 {
     /**
      * @param $id              The unique identifier for the store

--- a/src/Mailchimp/Error.php
+++ b/src/Mailchimp/Error.php
@@ -8,7 +8,7 @@
  * @copyright Ebizmarts (http://ebizmarts.com)
  * @license     http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
  * @date: 4/27/16 4:45 PM
- * @file: Exceptions.php
+ * @file: Error.php
  */
 class Mailchimp_Error extends Exception
 {

--- a/src/Mailchimp/HttpError.php
+++ b/src/Mailchimp/HttpError.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * mailchimp-lib Magento Component
+ *
+ * @category Ebizmarts
+ * @package mailchimp-lib
+ * @author Ebizmarts Team <info@ebizmarts.com>
+ * @copyright Ebizmarts (http://ebizmarts.com)
+ * @license http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * @date: 2020-10-03
+ * @file: HttpError.php
+ */
+class Mailchimp_HttpError extends Mailchimp_Error
+{
+}

--- a/src/Mailchimp/ListInterestCategoryInterests.php
+++ b/src/Mailchimp/ListInterestCategoryInterests.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * @deprecated 3.0.32 Please use correct spelling of 'lists'.
+ */
+class Mailchimp_ListInterestCategoryInterests extends Mailchimp_ListsInterestCategoryInterests
+{
+}

--- a/src/Mailchimp/ListsInterestCategory.php
+++ b/src/Mailchimp/ListsInterestCategory.php
@@ -13,7 +13,7 @@
 class Mailchimp_ListsInterestCategory extends Mailchimp_Abstract
 {
     /**
-     * @var Mailchimp_ListInterestCategoryInterests
+     * @var Mailchimp_ListsInterestCategoryInterests
      */
     public $interests;
 

--- a/src/Mailchimp/ListsInterestCategoryInterests.php
+++ b/src/Mailchimp/ListsInterestCategoryInterests.php
@@ -10,7 +10,7 @@
  * @date: 5/2/16 4:07 PM
  * @file: ListsInterestCategoryInterests.php
  */
-class Mailchimp_ListInterestCategoryInterests extends Mailchimp_Abstract
+class Mailchimp_ListsInterestCategoryInterests extends Mailchimp_Abstract
 {
     /**
      * @param $listId               The unique id for the list.


### PR DESCRIPTION
When using the recommended flag with composer `--optimize-autoloader`, the following warnings are omitted:

> Deprecation Notice: Class Mailchimp_Error located in ./vendor/ebizmarts/mailchimp-lib/src/Mailchimp/Exceptions.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Mailchimp_HttpError located in ./vendor/ebizmarts/mailchimp-lib/src/Mailchimp/Exceptions.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Mailchimp_ListInterestCategoryInterests located in ./vendor/ebizmarts/mailchimp-lib/src/Mailchimp/ListsInterestCategoryInterests.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Mailchimp_AutomationEmailsQuque located in ./vendor/ebizmarts/mailchimp-lib/src/Mailchimp/AutomationEmailsQueue.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Mailchimp_EcommerceStore located in ./vendor/ebizmarts/mailchimp-lib/src/Mailchimp/EcommerceStores.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201

This pull request fixes these, maintaining backwards compatibility.